### PR TITLE
Add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+# Prepares the Jekyll toolchain so `jekyll doctor` (lint), `jekyll build`
+# and `htmlproofer` (tests) work out of the box in a remote session.
+set -euo pipefail
+
+# Only run in the remote (Claude Code on the web) environment. Local machines
+# are assumed to already have the developer's own setup.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# --- Ruby version -----------------------------------------------------------
+# The project pins Ruby 3.2.x (.ruby-version says 3.2.3). Jekyll 3.9.x is
+# incompatible with Ruby 3.3+ (logger API change), and the container ships
+# Ruby 3.2.6 via rbenv, so we pin to that for the whole session.
+RUBY_VERSION_TO_USE="3.2.6"
+if command -v rbenv >/dev/null 2>&1; then
+  eval "$(rbenv init - bash)"
+  export RBENV_VERSION="$RUBY_VERSION_TO_USE"
+fi
+
+# A UTF-8 locale is required, otherwise Nokogiri (used by html-proofer) reads
+# the UTF-8 pages as US-ASCII and silently checks 0 links.
+export LANG="C.UTF-8"
+export LC_ALL="C.UTF-8"
+
+echo "Using Ruby: $(ruby --version)"
+
+# --- Git submodules (Jekyll plugins) ----------------------------------------
+git submodule update --init --recursive
+
+# --- Ruby gems --------------------------------------------------------------
+# Vendor the gems locally; this directory is cached with the container, so a
+# plain `bundle install` (not `bundle ci`) reuses it on subsequent runs.
+bundle config set --local path 'vendor/bundle'
+bundle install
+
+# --- Persist environment for the rest of the session ------------------------
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export RBENV_VERSION=\"$RUBY_VERSION_TO_USE\""
+    echo "export LANG=\"C.UTF-8\""
+    echo "export LC_ALL=\"C.UTF-8\""
+  } >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "Session setup complete: gems installed, submodules ready."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md
+
+> Operating guide for AI agents (and humans) working in this repository.
+> Read this together with [`CONTEXT.md`](CONTEXT.md), which explains the
+> project architecture, branch model, and toolchain.
+
+## Maintenance contract (MANDATORY)
+
+**For ANY change of ANY kind** — a feature, a bug fix, a refactor, a content
+edit, a tooling/config tweak, a dependency bump, or a change of context — you
+**MUST** update:
+
+1. This file (`AGENTS.md`) — if workflow, commands, or conventions change.
+2. [`CONTEXT.md`](CONTEXT.md) — if architecture, layout, toolchain, or context
+   changes.
+3. **Every other relevant document** (e.g. `README.md`, inline docs, comments).
+
+This is not optional. Treat the docs as part of the change: a change is "done"
+only when the documentation that describes it is true again. If a change makes
+any statement in these files inaccurate, fix the statement in the same commit.
+Write these files in **English** and keep them human-readable.
+
+## Golden rules
+
+- **Develop on `dev`** (or a branch based on `dev`). `dev` holds the source.
+- **Never edit or target `master`.** It is the machine-generated deploy output.
+  Pull requests MUST use `base: dev`.
+- **Never commit build artifacts.** `_site/`, `vendor/`, `.bundle/`,
+  `.jekyll-cache/`, etc. are git-ignored — keep them that way.
+- **Keep `Gemfile.lock` stable.** Don't let an incidental `bundle install`
+  bump locked versions; revert unintended lockfile drift before committing.
+- Match the surrounding style of files you touch.
+
+## Environment setup
+
+Requirements: Ruby `3.2.x` (NOT 3.3+, see CONTEXT.md), Bundler, Node.js,
+Python 3, and a **UTF-8 locale**.
+
+```bash
+git submodule update --init --recursive   # premonition + SgEExt plugins
+bundle config set --local path vendor/bundle
+bundle install
+export LANG=C.UTF-8 LC_ALL=C.UTF-8         # required for html-proofer/Nokogiri
+```
+
+On **Claude Code on the web**, the SessionStart hook
+(`.claude/hooks/session-start.sh`) does all of the above automatically:
+it pins Ruby 3.2.6 via rbenv, sets the UTF-8 locale, initializes submodules,
+runs `bundle install`, and persists `RBENV_VERSION`/`LANG`/`LC_ALL` for the
+session. It only runs when `CLAUDE_CODE_REMOTE=true`. If you change the build,
+dependencies, or required env, **update that hook too**.
+
+## Common commands
+
+All commands assume the environment above (UTF-8 locale + Ruby 3.2.x).
+
+| Task                 | Command                                                  |
+| -------------------- | -------------------------------------------------------- |
+| Lint / sanity check  | `bundle exec jekyll doctor`                              |
+| Build (CI-style)     | `CI=true ./_scripts/build`                               |
+| Build (plain)        | `bundle exec jekyll build`                               |
+| Test (links/assets)  | `bundle exec htmlproofer ./_site --disable-external`     |
+| Serve locally        | `bash ./_scripts/serve`  (livereload + drafts)           |
+| New draft            | `bash ./_scripts/draft "My Post Title"`                  |
+| Publish drafts       | `bash ./_scripts/publish`                                |
+| Regenerate emojis    | `bash ./_scripts/emojis`                                 |
+
+Notes on `_scripts/`:
+- `build` — runs `jekyll doctor`, then builds. In CI (`CI=true`) it writes
+  `_data/ci-status.yml` and runs `jekyll build`; otherwise it publishes drafts,
+  regenerates emojis, builds with `--drafts --trace`. It finishes with
+  `htmlproofer ./_site --disable-external`.
+- `draft` — scaffolds `_drafts/<slug>.md.draft` from `_templates/post.md`.
+- `publish` — promotes `_drafts/*.draft` into dated `_posts/` entries.
+- `emojis` — extracts emoji shortcodes from posts into `assets/img/emoji/`
+  (Python 3 + the SgEExt submodule).
+
+## Validating a change before pushing
+
+At minimum run the lint + build + test trio and confirm `htmlproofer` actually
+checks a non-zero number of links (if it reports "0 internal links", your
+locale is not UTF-8):
+
+```bash
+bundle exec jekyll doctor \
+  && bundle exec jekyll build \
+  && bundle exec htmlproofer ./_site --disable-external
+```
+
+## Git & PR conventions
+
+- Branch off `dev`; push your feature branch; open PRs against `dev`.
+- CI runs only on push to `dev`, so PRs won't show project CI status — verify
+  locally instead (see above).
+- Don't open a PR unless asked. Don't push to branches you weren't asked to.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,102 @@
+# CONTEXT.md
+
+> Repository context for both humans and AI agents.
+> **MANDATORY:** Any change of any kind — feature, fix, refactor, content,
+> tooling, context, or configuration — requires updating this file,
+> [`AGENTS.md`](AGENTS.md), and every other relevant document so they stay
+> truthful. See the "Maintenance contract" section below.
+
+## What this is
+
+This is the source of **klez.me** — the personal (static) website of
+Alessandro "kLeZ" Accardo. It is built with **Jekyll** and continuously
+deployed via **GitHub Actions**. The end-to-end flow is fully automated: write
+Markdown, push, and the public site updates within minutes.
+
+- Public URL: https://klez.me (see `CNAME`)
+- Repo: https://github.com/kLeZ/kLeZ.github.io
+- Licensing: GNU GPL v3 for site code, CC-BY-NC-ND 4.0 for content.
+
+## Branch architecture & CI/CD
+
+This repository uses **two long-lived branches with different roles**:
+
+| Branch   | Role                                                                 |
+| -------- | -------------------------------------------------------------------- |
+| `dev`    | **Source of truth.** Jekyll source, scripts, config, CI definition.  |
+| `master` | **Deploy target only.** Contains the built static output (`_site/`). |
+
+CI/CD (`.github/workflows/main.yaml`) is triggered **only on push to `dev`**:
+
+1. **build** job — checks out `dev` (with submodules), sets up Ruby, runs
+   `bundle install`, then `./_scripts/build`, and uploads `_site/` as an
+   artifact.
+2. **deploy** job — checks out `master`, downloads the `_site/` artifact, and
+   commits/pushes it back to `master` (the "Deployed new klez.me version"
+   commits).
+
+Implications:
+- **Develop on `dev`** (or a branch based on it). Pull requests must target
+  `dev`, **never `master`**.
+- Never hand-edit `master`; it is machine-generated.
+- The CI workflow does **not** run on `pull_request` events, only on push to
+  `dev`. PRs therefore show no project CI status — that is expected.
+
+## Toolchain
+
+- **Ruby**: project pins `3.2.3` via `.ruby-version`; CI uses `3.2.0`. Any
+  Ruby `3.2.x` works. **Ruby `3.3+` does NOT work** with the pinned
+  Jekyll 3.9.x (a `logger` API change breaks `jekyll`).
+- **Bundler / gems**: declared in `Gemfile`, locked in `Gemfile.lock`
+  (`BUNDLED WITH 2.4.10`). Jekyll 3.9.3 + plugins (feed, katex, seo-tag,
+  jemoji, tidy, git_metadata, postfiles, ...). `html-proofer` is used for
+  link/asset testing.
+- **Git submodules** (`.gitmodules`): two Jekyll plugins live as submodules
+  under `_plugins/` and MUST be initialized before building:
+  - `_plugins/premonition` (https://github.com/kLeZ/premonition.git)
+  - `_plugins/SgEExt` (https://github.com/HorlogeSkynet/SgEExt.git)
+- **Node.js** is used by some build steps; **Python 3** is used by the emoji
+  extractor (`_scripts/emojis` → `SgEExt/sgeext.py`).
+
+### Known gotchas
+
+- **UTF-8 locale required.** `html-proofer` (via Nokogiri) reads pages with the
+  process default encoding. Without a UTF-8 locale (`LANG`/`LC_ALL`), pages are
+  read as US-ASCII, Nokogiri throws `Encoding::InvalidByteSequenceError`, and
+  the proofer silently checks **0 links** while still exiting `0`. Always run
+  with `LANG=C.UTF-8 LC_ALL=C.UTF-8` (or another UTF-8 locale).
+- **Ruby 3.3+ incompatibility** — see Toolchain above.
+
+## Directory layout (on `dev`)
+
+```
+_config.yml        Jekyll configuration (site metadata, plugins, sass, katex...)
+_data/             Site data (incl. CI status written during build)
+_drafts/           Unpublished drafts (*.draft via _scripts/draft)
+_includes/         Liquid partials
+_layouts/          Page layouts
+_pages/            Standalone pages
+_plugins/          Ruby plugins + submodules (premonition, SgEExt)
+_posts/            Published blog posts
+_sass/             Sass sources (compiled, style: compressed)
+_scripts/          Build/dev helper scripts (see AGENTS.md)
+_templates/        Templates (e.g. post.md used by _scripts/draft)
+_xp/               "xp" collection
+apps/ lf/ media/   Content / assets
+assets/            Static assets (katex, emoji output, images, reveal.js...)
+.github/workflows/ CI/CD (main.yaml)
+.claude/           Claude Code config: SessionStart hook + settings
+```
+
+## Claude Code on the web
+
+A SessionStart hook (`.claude/hooks/session-start.sh`, registered in
+`.claude/settings.json`) prepares the toolchain for remote web sessions: it
+pins Ruby 3.2.6 via rbenv, sets a UTF-8 locale, initializes submodules, and
+runs `bundle install`. It only runs when `CLAUDE_CODE_REMOTE=true`. See
+[`AGENTS.md`](AGENTS.md) for how to work in this environment.
+
+## Maintenance contract
+
+Keeping these docs accurate is **not optional**. Read the rules in
+[`AGENTS.md`](AGENTS.md#maintenance-contract-mandatory).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Double licensing is provided: [GNU GPL v3] for the site code which you can freel
 
 Please be gentle :-)
 
+## Development
+
+Working on this repo (humans and AI agents alike)? Start here:
+
+- [`AGENTS.md`](AGENTS.md) — how to set up, build, test, and the working conventions.
+- [`CONTEXT.md`](CONTEXT.md) — project architecture, branch model, and toolchain.
+
+Note: develop on `dev` (the source branch); `master` only holds the deployed output.
+
 [Jekyll]: https://jekyllrb.com/
 [GitHub-Actions]: https://github.com/features/actions
 [GitHub]: https://github.com


### PR DESCRIPTION
## Cosa fa

Aggiunge un **SessionStart hook** per le sessioni di Claude Code sul web, così che il toolchain Jekyll sia pronto all'avvio (lint/build/test funzionanti out of the box).

La PR ha come base `dev` — il branch dove vive il sorgente Jekyll — non `master` (che contiene solo l'output statico deployato).

## Modifiche

- **`.claude/hooks/session-start.sh`** — gira solo in remoto (`CLAUDE_CODE_REMOTE`) e:
  - fissa **Ruby 3.2.6** via rbenv (Jekyll 3.9 è incompatibile con Ruby 3.3+; il container parte con 3.3.6)
  - imposta locale **UTF-8** (`C.UTF-8`), altrimenti Nokogiri/html-proofer leggono le pagine come US-ASCII e controllano 0 link
  - esegue `git submodule update --init --recursive` (plugin `premonition` e `SgEExt`)
  - esegue `bundle install` su `vendor/bundle` (cache-friendly)
  - persiste `RBENV_VERSION`/`LANG`/`LC_ALL` per la sessione via `CLAUDE_ENV_FILE`
- **`.claude/settings.json`** — registra l'hook

## Validazione (locale, in ambiente remoto)

- ✅ Esecuzione hook: exit 0, gem installate, submodule pronti, nessun drift su `Gemfile.lock`
- ✅ Linter `jekyll doctor`: *"Everything looks fine."*
- ✅ Test `jekyll build` + `htmlproofer ./_site --disable-external`: 176 link interni su 71 file, *"finished successfully"*

## Note

- Modalità hook: **sincrona** (garantisce le dipendenze pronte prima dell'avvio; avvio leggermente più lento). Convertibile in async se si preferisce.
- Una volta fatto il merge su `dev` (branch di default per lo sviluppo), tutte le sessioni web future useranno l'hook automaticamente.

https://claude.ai/code/session_011N4vhbYFmNyLBYgVaFrzjp

---
_Generated by [Claude Code](https://claude.ai/code/session_011N4vhbYFmNyLBYgVaFrzjp)_