### PR TITLE
ci: publish via GitHub Actions (deploy-pages) to stop the managed Jekyll build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,17 @@ env:
   JEKYLL_ENV: 'production'
   NOKOGIRI_USE_SYSTEM_LIBRARIES: true
 
+# Permessi necessari a deploy-pages: pubblicazione su GitHub Pages via OIDC.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Una sola pubblicazione Pages alla volta, senza annullare i deploy in corso.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -72,49 +83,20 @@ jobs:
       - name: Date-tag the build
         run: touch "_site/$(echo "deployed at `LANG=en_US date '+%a %b %d %H.%M.%S %Z %Y'` by GitHub Actions")"
 
-      - name: Upload built site as artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: site-release
           path: _site/
-          if-no-files-found: error
-
-      - name: Cleaning up
-        run: bundle exec jekyll clean
 
   deploy:
     runs-on: ubuntu-latest
     needs: build
 
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-        with:
-          ref: master
-
-      - name: Setup Git
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "admin@klez.me"
-          ls -l deployed*
-          rm -f deployed*
-
-      - name: Download built site artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: site-release
-
-      - name: Disable GitHub Pages implicit Jekyll build
-        run: touch .nojekyll
-
-      - name: Add Files to index
-        run: |
-          ls -l deployed*
-          git status
-          git add -A
-
-      - name: Commit and push added files
-        run: |
-          git status
-          git commit -m "Deployed new klez.me version"
-          git push
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Contesto

Il deploy su GitHub Pages falliva con `Liquid syntax error (line 88): Unknown tag 'feed_meta' in ACCESS-FILES.md`.

La causa non è la config Jekyll, ma una **sovrapposizione di build**: oltre alla pipeline del repo (che builda con il `_config.yml` completo e poi committa il compilato su `master`), girava anche la **build Jekyll gestita da GitHub Pages** ("pages build and deployment", `actions/jekyll-build-pages`). Quest'ultima eseguiva Jekyll sul *sorgente* presente su `master` — dove erano rimasti file sorgente stantii (`ACCESS-FILES.md`, ecc.) e nessun `_config.yml` valido (quindi niente `jekyll-feed`) — e falliva sul literal `{% feed_meta %}`. `.nojekyll` non ferma questa build gestita.

## Modifiche

Passaggio al flusso Pages basato su Actions, in `.github/workflows/main.yaml`:

- Aggiunti `permissions` (`pages: write`, `id-token: write`) e `concurrency` a livello di workflow.
- Job `build`: invariata la build (`_scripts/build`); l'upload ora usa `actions/upload-pages-artifact@v3` (path `_site/`); rimosso lo step `jekyll clean` superfluo.
- Job `deploy`: rimosso il giro "checkout master → commit → push" (e lo step `.nojekyll` inefficace); ora pubblica con `actions/deploy-pages@v4` ed `environment: github-pages`.

Risultato: pubblica **solo** questa action (con `jekyll-feed` ecc.); nessuna build Jekyll gestita gira più. `CNAME`/dominio `klez.me` preservato perché incluso in `_site`.

## ⚠️ Azione manuale necessaria

Impostare **Settings → Pages → Build and deployment → Source = "GitHub Actions"**. Senza questo toggle il nuovo deploy non diventa la sorgente di pubblicazione.

## Verifica

1. Merge su `dev` → parte `main.yaml`: build senza errore `feed_meta`, upload artifact, `deploy-pages` pubblica.
2. Nella tab Actions non deve più comparire/fallire il job gestito "pages build and deployment".
3. Sito servito correttamente su `klez.me` (home, `/about`, `/cv`, `/blog`, post, `feed.xml`, `sitemap.xml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015pnFnMpS2Scgt7ZJemRhYp)_